### PR TITLE
Fix foreign key constraint not being used on subsequent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.6
+
+* Re-enable foreign key constraint for every session
+  * Clean up unused indices which were not automatically removed before (but will be going forward)
+
 ## 1.4.5
 
 * try/catch with `ROLLBACK` in case a transaction fails, so as to not leave the database in a locked state

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.5"
+    version: "1.4.6"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: indexed_entity_store
 description: A fast, simple, and synchronous entity store for Flutter applications.
-version: 1.4.5
+version: 1.4.6
 repository: https://github.com/LunaONE/indexed_entity_store
 
 environment:


### PR DESCRIPTION
Foreign keys need to be re-enable with each session

Otherwise e.g. `ON DELETE CASCADE` for the automatic index removal does not work.

Revert explicit delete introduced in 9bcc24df556bb002040a1682a8659c289f5f25e4